### PR TITLE
v1.1.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python-envs.defaultEnvManager": "ms-python.python:venv",
+    "python-envs.pythonProjects": []
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+bleak
+bleak-retry-connector

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ with open('pyprobeplus/__init__.py', 'r', encoding='utf8') as version_file:
 
 REQUIREMENTS = [
     'bleak',
+    'bleak-retry-connector',
 ]
 
 DEV_REQUIREMENTS = [


### PR DESCRIPTION
Minor code quality improvements

Uses the bleak-retry-connector to fix warning:

```
 EA:00:00:02:74:EC: BleakClient.connect() called without bleak-retry-connector. For reliable connection establishment, use bleak_retry_connector.establish_connection(). See https://github.com/Bluetooth-Devices/bleak-retry-connector 
```